### PR TITLE
Asynchronous Image Loading

### DIFF
--- a/runtime/src/main/as/flump/executor/load/BaseLoader.as
+++ b/runtime/src/main/as/flump/executor/load/BaseLoader.as
@@ -8,6 +8,7 @@ import flash.events.Event;
 import flash.events.IOErrorEvent;
 import flash.net.URLRequest;
 import flash.system.ApplicationDomain;
+import flash.system.ImageDecodingPolicy;
 import flash.system.LoaderContext;
 import flash.utils.ByteArray;
 
@@ -50,6 +51,7 @@ public class BaseLoader
         } else {
             context.applicationDomain = ApplicationDomain.currentDomain;
         }
+        context.imageDecodingPolicy = ImageDecodingPolicy.ON_LOAD;
         return exec.submit(function (onSuccess :Function, onFail :Function) :void {
             const loader :Loader = new Loader();
             loader.contentLoaderInfo.addEventListener(Event.INIT, function (..._) :void {


### PR DESCRIPTION
Changed the imageDecodingPolicy to ON_LOAD, which asynchornously
decodes the image before calling the complete event. This change
improves the responsiveness of the UI while loading flump pacakges.

See Adobe's documentation for more details:
http://help.adobe.com/en_US/as3/dev/WS52621785137562065a8e668112d98c8c4df-8000.html
