### PR TITLE
BitmapData Quality Settings .drawWithQuality()

### DIFF
--- a/exporter/src/main/as/flump/SwfTexture.as
+++ b/exporter/src/main/as/flump/SwfTexture.as
@@ -8,6 +8,7 @@ import flash.display.BitmapData;
 import flash.display.DisplayObject;
 import flash.display.MovieClip;
 import flash.display.Sprite;
+import flash.display.StageQuality;
 import flash.geom.Point;
 import flash.geom.Rectangle;
 
@@ -22,30 +23,32 @@ public class SwfTexture
     public var origin :Point;
     public var w :int, h :int, a :int;
     public var scale :Number;
+    public var quality :String;
 
     public static function fromFlipbook (lib :XflLibrary, movie :MovieMold, frame :int,
-        scale :Number = 1) :SwfTexture {
+        quality :String = StageQuality.BEST, scale :Number = 1) :SwfTexture {
 
         const klass :Class = Class(lib.swf.getSymbol(movie.id));
         const clip :MovieClip = MovieClip(new klass());
         clip.gotoAndStop(frame + 1);
         const name :String = movie.id + "_flipbook_" + frame;
-        return new SwfTexture(name, clip, scale);
+        return new SwfTexture(name, clip, scale, quality);
     }
 
     public static function fromTexture (swf :LoadedSwf, tex :XflTexture,
-        scale :Number = 1) :SwfTexture {
+        quality :String = StageQuality.BEST, scale :Number = 1) :SwfTexture {
 
         const klass :Class = Class(swf.getSymbol(tex.symbol));
         const instance :Object = new klass();
         const disp :DisplayObject = (instance is BitmapData) ?
             new Bitmap(BitmapData(instance)) : DisplayObject(instance);
-        return new SwfTexture(tex.symbol, disp, scale);
+        return new SwfTexture(tex.symbol, disp, scale, quality);
     }
 
-    public function SwfTexture (symbol :String, disp :DisplayObject, scale :Number) {
+    public function SwfTexture (symbol :String, disp :DisplayObject, scale :Number, quality :String) {
         this.symbol = symbol;
         this.scale = scale;
+        this.quality = quality;
         _disp = disp;
 
         origin = getOrigin(_disp, scale);
@@ -57,7 +60,7 @@ public class SwfTexture
     }
 
     public function toBitmapData (borderPadding :int = 0) :BitmapData {
-        const bmd :BitmapData = Util.renderToBitmapData(_disp, w, h, scale);
+        const bmd :BitmapData = Util.renderToBitmapData(_disp, w, h, quality, scale);
         return (borderPadding > 0 ? Util.padBitmapBorder(bmd, borderPadding) : bmd);
     }
 

--- a/exporter/src/main/as/flump/Util.as
+++ b/exporter/src/main/as/flump/Util.as
@@ -101,7 +101,7 @@ public class Util
     }
 
     public static function renderToBitmapData (src :IBitmapDrawable, w :int, h :int,
-        scale :Number = 1, multipassScaleThreshold :Number = 0.5) :BitmapData {
+        quality:String, scale :Number = 1, multipassScaleThreshold :Number = 0.5) :BitmapData {
 
         var bounds :Rectangle = getBitmapDrawableBounds(src);
 
@@ -109,7 +109,7 @@ public class Util
             // for down or up-scaling, render at normal size first, then scale to get the
             // benefit of bitmap smoothing. BitmapData.draw smoothing only works
             // when the source is itself a BitmapData object.
-            src = renderToBitmapData(src, Math.ceil(bounds.width), Math.ceil(bounds.height), 1);
+            src = renderToBitmapData(src, Math.ceil(bounds.width), Math.ceil(bounds.height), quality, 1);
             bounds = getBitmapDrawableBounds(src);
         }
 
@@ -121,7 +121,7 @@ public class Util
         while (targetScale < multipassScaleThreshold) {
             targetW *= multipassScaleThreshold;
             targetH *= multipassScaleThreshold;
-            src = renderToBitmapData(src, Math.ceil(targetW), Math.ceil(targetH), multipassScaleThreshold);
+            src = renderToBitmapData(src, Math.ceil(targetW), Math.ceil(targetH), quality, multipassScaleThreshold);
             targetScale /= multipassScaleThreshold;
         }
         bounds = getBitmapDrawableBounds(src);
@@ -130,7 +130,7 @@ public class Util
         var m :Matrix = new Matrix();
         m.translate(-bounds.x, -bounds.y);
         m.scale(targetScale, targetScale);
-        bmd.draw(src, m, null, null, null, true);
+        bmd.drawWithQuality(src, m, null, null, null, true, quality);
         return bmd;
     }
 

--- a/exporter/src/main/as/flump/export/EditFormatsWindow.mxml
+++ b/exporter/src/main/as/flump/export/EditFormatsWindow.mxml
@@ -41,6 +41,26 @@
             </fx:Component>
           </s:itemEditor>
         </s:GridColumn>
+          <s:GridColumn dataField="quality" headerText="Quality">
+            <s:itemEditor>
+              <fx:Component>
+                <s:ComboBoxGridItemEditor>
+                  <s:dataProvider>
+                    <s:ArrayList>
+                      <fx:String>low</fx:String>
+                      <fx:String>medium</fx:String>
+                      <fx:String>high</fx:String>
+                      <fx:String>best</fx:String>
+                      <fx:String>8x8</fx:String>
+                      <fx:String>8x8linear</fx:String>
+                      <fx:String>16x16</fx:String>
+                      <fx:String>16x16linear</fx:String>
+                    </s:ArrayList>
+                  </s:dataProvider>
+                </s:ComboBoxGridItemEditor>
+              </fx:Component>
+            </s:itemEditor>
+          </s:GridColumn>
       </s:ArrayList>
     </s:columns>
     <mx:ArrayCollection/>

--- a/exporter/src/main/as/flump/export/ExportConf.as
+++ b/exporter/src/main/as/flump/export/ExportConf.as
@@ -3,6 +3,7 @@
 
 package flump.export {
 
+import flash.display.StageQuality;
 import flash.filesystem.File;
 
 import flump.mold.AtlasMold;
@@ -31,6 +32,8 @@ public class ExportConf
     public var additionalScaleFactors :Array = [];
     /** The optimization strategy. */
     public var optimize :String = OPTIMIZE_MEMORY;
+    /** The stage quality setting (StageQuality). */
+    public var quality :String = StageQuality.BEST;
 
     public function get scaleFactorsString () :String {
         return this.additionalScaleFactors.join(",");
@@ -72,6 +75,7 @@ public class ExportConf
         conf.maxAtlasSize = optional(o, "maxAtlasSize", 2048);
         conf.additionalScaleFactors = optional(o, "additionalScaleFactors", []);
         conf.optimize = optional(o, "optimize", OPTIMIZE_MEMORY);
+        conf.quality = optional(o, "quality", StageQuality.BEST);
         return conf;
     }
 

--- a/exporter/src/main/as/flump/export/PublishFormat.as
+++ b/exporter/src/main/as/flump/export/PublishFormat.as
@@ -25,6 +25,7 @@ public class PublishFormat
             .borderSize(_conf.textureBorder)
             .maxAtlasSize(_conf.maxAtlasSize)
             .optimizeForSpeed(_conf.optimize == ExportConf.OPTIMIZE_SPEED)
+            .quality(_conf.quality)
             .filenamePrefix(prefix);
 
         var atlases :Vector.<Atlas> = packer.scaleFactor(1).createAtlases(); // 1x atlases


### PR DESCRIPTION
Adds support for changing the StageQuality setting used to render the
BitmapData when generting textures.

The default setting is StageQuality.BEST, however BEST is a relative
term since newer versions of the Flash Player have given us HIGH_8x8,
HIGH_8X8_LINEAR, HIGH_16x16, and HIGH_16X16_LINEAR.

Regarding Issue #39
