### PR TITLE
Publish error msgs

### DIFF
--- a/exporter/src/main/as/flump/export/ProjectController.as
+++ b/exporter/src/main/as/flump/export/ProjectController.as
@@ -360,10 +360,12 @@ public class ProjectController
         stage.quality = StageQuality.BEST;
 
         try {
-            if (_exportChooser.dir == null)
+            if (_exportChooser.dir == null) {
                 throw new Error("No export directory specified.");
-            if (_conf.exports.length == 0)
+            }
+            if (_conf.exports.length == 0) {
                 throw new Error("No export formats specified.");
+            }
             createPublisher().publish(status.lib);
         } catch (e :Error) {
             ErrorWindowMgr.showErrorPopup("Publishing Failed", e.message, _win);


### PR DESCRIPTION
Provide user-friendly error messages for the following 2 "Publish Failed" conditions:

1) No export directory specified
2) No export formats specified

Previous failure message was flash null reference error text.
