### PR TITLE
SwfTexture rendering improvements

### DIFF
--- a/exporter/src/main/as/flump/SwfTexture.as
+++ b/exporter/src/main/as/flump/SwfTexture.as
@@ -21,6 +21,8 @@ import flump.mold.MovieMold;
 import flump.xfl.XflLibrary;
 import flump.xfl.XflTexture;
 
+import com.threerings.display.DisplayUtil;
+
 public class SwfTexture
 {
     public var symbol :String;
@@ -136,30 +138,19 @@ public class SwfTexture
         _w = _visualBounds.width;
         _h = _visualBounds.height;
     }
-    
+
     private function hasPotentiallySizeAlteringFilters(dObj:DisplayObject) :Boolean {
-        // check dObj's filter list
-        var filters:Array = dObj.filters;
-        for (var ff:int = 0, nf:int = filters.length; ff < nf; ++ff) {
-            // all standard filters except ColorMatrixFilter can change the visual bounds
-            if (!(filters[ff] is ColorMatrixFilter)) {
-                return true;
-            }
-        }
-        // recursively check children
-        var dObjContainer:flash.display.DisplayObjectContainer = dObj as flash.display.DisplayObjectContainer;
-        if (dObjContainer) {
-            for (var cc:int = 0, nc:int = dObjContainer.numChildren; cc < nc; ++cc) {
-                var child:DisplayObject = dObjContainer.getChildAt(cc);
-                if (hasPotentiallySizeAlteringFilters(child)) {
+        return DisplayUtil.applyToHierarchy(dObj, function (disp :DisplayObject) :Boolean {
+            for each (var filter :Object in disp.filters) {
+                // all standard filters except ColorMatrixFilter can change the visual bounds
+                if (!(filter is ColorMatrixFilter)) {
                     return true;
                 }
             }
-        }
-        // all clear
-        return false;        
+            return false;
+        });
     }
-    
+
     private var _disp :DisplayObjectContainer;
     private var _w :int, _h :int;
     private var _origin :Point;


### PR DESCRIPTION
Features:

1) Renders display object to target size directly from vector renderer (as per Issue #32), unless display object contains children with filters.  

2) When display object contains children with filters, calculates full visual bounds and scales to target size from bitmapdata of scale 1 vector render.  
    -  Fixes cropping of filter pixels in textures
    -  Allows filter settings within a display object to "scale" with exporter scale settings.

These features are beneficial independent of the bake-in-filters feature (separate pull request).
