### PR TITLE
Preview->Show Atlas uses and shows texture padding setting, similar to scale setting

### DIFF
--- a/exporter/src/main/as/flump/export/AtlasPreviewWindow.mxml
+++ b/exporter/src/main/as/flump/export/AtlasPreviewWindow.mxml
@@ -7,8 +7,11 @@
       <s:VerticalLayout/>
     </s:layout>
     <s:HGroup>
-      <s:Button id="setScale" label="Set Scale:"/>
-      <s:TextInput id="scale" width="100" restrict=".0123456789" text="1"/>
+      <s:Label text="Scale:" alignmentBaseline="descent" width="40" />
+      <s:TextInput id="scale" widthInChars="3" restrict=".0123456789" text="1"/>
+      <s:Label text="Border:" alignmentBaseline="descent" width="50" />
+      <s:TextInput id="border" widthInChars="3" restrict="0123456789" text="1"/>
+      <s:Button id="preview" label="Preview"/>
     </s:HGroup>
     <s:Scroller id="scroller" width="100%" height="100%" horizontalScrollPolicy="auto" verticalScrollPolicy="auto">
       <s:Group>

--- a/exporter/src/main/as/flump/export/PreviewController.as
+++ b/exporter/src/main/as/flump/export/PreviewController.as
@@ -93,19 +93,23 @@ public class PreviewController
 
         // default our atlas scale to our export scale
         var scale :Number = 1;
+        var border :int = 1;
         if (_project.exports.length > 0) {
             const exportConf :ExportConf = _project.exports[0];
             scale = exportConf.scale;
+            border = exportConf.textureBorder;
         }
         _atlasPreviewWindow.scale.text = "" + scale;
-        _atlasPreviewWindow.setScale.addEventListener(MouseEvent.CLICK, F.callback(updateAtlas));
+        _atlasPreviewWindow.border.text = "" + border;
+        _atlasPreviewWindow.preview.addEventListener(MouseEvent.CLICK, F.callback(updateAtlas));
         updateAtlas();
     }
 
     protected function updateAtlas () :void {
         // create our atlases
         const scale :Number = MathUtil.clamp(Number(_atlasPreviewWindow.scale.text), 0.001, 1);
-        const atlases :Vector.<Atlas> = TexturePacker.withLib(_lib).baseScale(scale).createAtlases();
+        const border :int = Math.max(0, int(_atlasPreviewWindow.border.text));
+        const atlases :Vector.<Atlas> = TexturePacker.withLib(_lib).baseScale(scale).borderSize(border).createAtlases();
 
         const sprite :flash.display.Sprite = new flash.display.Sprite();
         for (var ii :int = 0; ii < atlases.length; ++ii) {


### PR DESCRIPTION
I noticed that the preview of the Texture Atlas does not use the texture padding setting from the default export format the same way that it does the scale.

This change updates the Texture Atlas preview to display and use that texture padding setting so that the preview of the atlas is more in line with the actual export.
