### PR TITLE
Handle "No keyframes in Layer" safely

### DIFF
--- a/runtime/src/main/as/flump/mold/LayerMold.as
+++ b/runtime/src/main/as/flump/mold/LayerMold.as
@@ -27,6 +27,7 @@ public class LayerMold
     }
 
     public function get frames () :int {
+        if (keyframes.length == 0) return 0;
         const lastKf :KeyframeMold = keyframes[keyframes.length - 1];
         return lastKf.index + lastKf.duration;
     }


### PR DESCRIPTION
As "No keyframes in layer" is an 'INFO' error, not a 'CRIT', the code should be able to survive parsing without throwing an exception when this situation is encountered.

Change: LayerMold.frames does not crash if numFrames is zero.
