### PR TITLE
Ignore layers of type "folder", which inherently have no keyframes

### DIFF
--- a/exporter/src/main/as/flump/xfl/XflMovie.as
+++ b/exporter/src/main/as/flump/xfl/XflMovie.as
@@ -57,7 +57,8 @@ public class XflMovie
             }
         } else {
             for each (var layerEl :XML in layerEls) {
-                if (XmlUtil.getStringAttr(layerEl, "layerType", "") != "guide") {
+                var layerType:String = XmlUtil.getStringAttr(layerEl, "layerType", "");
+                if ((layerType != "guide") && (layerType != "folder")) {
                     movie.layers.unshift(XflLayer.parse(lib, location, layerEl, false));
                 }
             }


### PR DESCRIPTION
"Folder" layers, used for organizational purposes within the Flash CS editor, have no keyframes, causing a 'No keyframes in layer' warning.

This change skips parsing of folder layers.
