### PR TITLE
Never terminate until we've shutdown.

### DIFF
--- a/runtime/src/main/as/flump/executor/Executor.as
+++ b/runtime/src/main/as/flump/executor/Executor.as
@@ -156,7 +156,7 @@ public class Executor
 
     /** @private */
     protected function terminateIfNecessary () :void {
-        if (_terminated || !isIdle) return;
+        if (!_shutdown || _terminated || !isIdle) return;
         _terminated = true;
         terminated.emit(this);
     }


### PR DESCRIPTION
The docs on isTerminated() claim that this should be the case, but as it was written, if the
Executor goes idle, then is given more tasks before shutting down, it was in a bad state because
it had already internally terminated.
