### PR TITLE
Respect the library's mipmap setting for ATF textures too.

### DIFF
--- a/runtime/src/main/as/flump/display/Loader.as
+++ b/runtime/src/main/as/flump/display/Loader.as
@@ -115,7 +115,7 @@ internal class Loader {
         ByteArray(bytes).position = 0; // reset the read head
         var scale :Number = atlas.scaleFactor;
         if (_lib.textureFormat == "atf") {
-            baseTextureLoaded(Texture.fromAtfData(bytes, scale), atlas);
+            baseTextureLoaded(Texture.fromAtfData(bytes, scale, _libLoader.generateMipMaps), atlas);
             ByteArray(bytes).clear();
         } else {
             const atlasFuture :Future = loader.loadFromBytes(bytes, _pngLoaders);


### PR DESCRIPTION
I should note that this is a potentially breaking change for anybody out there actually using ATF (unlikely, but hey). The flump default is to turn off mipmapping, but the png2atf default is to have it on. So, someone using the defaults previously would now need to set generateMipMaps true on their loader when they previously would not have.
