### PR TITLE
Add stopAt(position), play() to Movie interface

### DIFF
--- a/runtime/src/main/as/flump/display/Movie.as
+++ b/runtime/src/main/as/flump/display/Movie.as
@@ -119,10 +119,33 @@ public class Movie extends Sprite
     * a label on this movie.
     */
     public function playTo (position :Object) :Movie {
-       _stopFrame = extractFrame(position);
-       // don't play if we're already at the stop frame
-       _playing = (_frame != _stopFrame);
-       return this;
+       // won't play if we're already at the stop position
+       return stopAt(position).play();
+    }
+
+    /** Sets the stop frame for this Movie.
+     *
+     * @param position the int frame or String label to stop at.
+     *
+     * @return this movie for chaining
+     *
+     * @throws Error if position isn't an int or String, or if it is a String and that String isn't
+     * a label on this movie.
+     */
+    public function stopAt (position :Object) :Movie {
+        _stopFrame = extractFrame(position);
+        return this;
+    }
+
+    /** Sets the movie playing.  Movie will automatically stop at its stopFrame, if one is set, 
+     *  otherwise it will loop forever.
+     *
+     * @return this movie for chaining
+     */
+    public function play () :Movie {
+        // set playing to true unless movie is at the stop frame
+        _playing = (_frame != _stopFrame) || (_stopFrame == NO_FRAME);
+        return this;
     }
 
     /** Stops playback if it's currently active. Doesn't alter the current frame or stop frame. */
@@ -155,7 +178,6 @@ public class Movie extends Sprite
                 if (framesElapsed >= framesRemaining) {
                     _playing = false;
                     newFrame = _stopFrame;
-                    _stopFrame = NO_FRAME;
                 }
             }
             updateFrame(newFrame, dt);


### PR DESCRIPTION
Adds the following public methods to the Movie interface:

```
/** Sets the stop frame for this Movie.
 *
 * @param position the int frame or String label to stop at.
 *
 * @return this movie for chaining
 */
public function stopAt (position :Object) :Movie;

/** Sets the movie playing.  Movie will automatically stop at its stopFrame, if one is set, 
 *  otherwise it will loop forever.
 *
 * @return this movie for chaining
 */
public function play () :Movie;
```
