### PR TITLE
fixes to layers managing symbols via visibility

### DIFF
--- a/runtime/src/main/as/flump/display/Layer.as
+++ b/runtime/src/main/as/flump/display/Layer.as
@@ -151,14 +151,16 @@ internal class Layer
     }
 
     /** Expands the given bounds to include the bounds of this Layer's current display object. */
-    internal function expandBounds(targetSpace :DisplayObject, resultRect :Rectangle) :Rectangle {
+    internal function expandBounds (targetSpace :DisplayObject, resultRect :Rectangle) :Rectangle {
         // if no objects on this frame, do not change bounds
-        if (_keyframes[_keyframeIdx].ref == null)
+        if (_keyframes[_keyframeIdx].ref == null) {
             return resultRect;
+        }
 
         // if no rect was incoming, the resulting bounds is exactly the bounds of the display
-        if (resultRect.isEmpty())
+        if (resultRect.isEmpty()) {
             return _currentDisplay.getBounds(targetSpace, resultRect);
+        }
 
         // otherwise expand bounds by current display's bounds, if it has any
         var layerRect :Rectangle = _currentDisplay.getBounds(targetSpace);

--- a/runtime/src/main/as/flump/display/Movie.as
+++ b/runtime/src/main/as/flump/display/Movie.as
@@ -209,7 +209,7 @@ public class Movie extends Sprite
      *
      * Modified from starling.display.DisplayObjectContainer
      */
-    public override function getBounds(targetSpace :DisplayObject, resultRect :Rectangle=null) :Rectangle {
+    public override function getBounds (targetSpace :DisplayObject, resultRect :Rectangle=null) :Rectangle {
         if (resultRect == null) {
             resultRect = new Rectangle();
         } else {
@@ -217,8 +217,8 @@ public class Movie extends Sprite
         }
 
         // get bounds from layer contents
-        for (var ii :int = 0; ii < _layers.length; ii++) {
-            _layers[ii].expandBounds(targetSpace, resultRect);
+        for each (var layer :Layer in _layers) {
+            layer.expandBounds(targetSpace, resultRect);
         }
 
         // if no contents exist, simply include this movie's position in the bounds
@@ -366,9 +366,9 @@ public class Movie extends Sprite
     /** @private */
     internal var _playerData :MoviePlayerNode;
     /** @private */
-    private static var _s_helperPoint:Point = new Point();
+    private static var _s_helperPoint :Point = new Point();
 
-    private static const IDENTITY_MATRIX:Matrix = new Matrix();
+    private static const IDENTITY_MATRIX :Matrix = new Matrix();
 
     private static const NO_FRAME :int = -1;
 


### PR DESCRIPTION
remove frameOverShootDisplay sprite:
Having an extra _frameOvershootDisplay Sprite is unnecessary in the new visibility scheme.

fix getBounds for Movies to not include placeholder Sprites used in Layers where no symbol exists on a frame
I hadn't meant to submit this just yet but it went through on the same branch pull request, so here it is for your review.  If this is feeling heavy handed to you guys, let me know.  
