### PR TITLE
Class Flipbook

### DIFF
--- a/exporter/src/main/as/flump/xfl/XflMovie.as
+++ b/exporter/src/main/as/flump/xfl/XflMovie.as
@@ -46,7 +46,7 @@ public class XflMovie extends XflSymbol
         const location :String = lib.location + ":" + movie.id;
 
         const layerEls :XMLList = xml.timeline.DOMTimeline[0].layers.DOMLayer;
-        if (XmlUtil.getStringAttr(layerEls[0], XflLayer.NAME) == "flipbook") {
+        if (XmlUtil.getStringAttr(xml, EXPORT_BASE_CLASS_NAME, null)=="Flipbook" || XmlUtil.getStringAttr(layerEls[0], XflLayer.NAME) == "flipbook") {
             movie.layers.push(XflLayer.parse(lib, location, layerEls[0], true));
             if (exportName == null) {
                 lib.addError(location, ParseError.CRIT, "Flipbook movie '" + movie.id + "' not exported");

--- a/exporter/src/main/as/flump/xfl/XflSymbol.as
+++ b/exporter/src/main/as/flump/xfl/XflSymbol.as
@@ -16,6 +16,7 @@ public class XflSymbol
     public static const EXPORT_FOR_ACTIONSCRIPT :String = "linkageExportForAS";
     public static const EXPORT_IN_FIRST_FRAME :String = "linkageExportInFirstFrame";
     public static const EXPORT_CLASS_NAME :String = "linkageClassName";
+    public static const EXPORT_BASE_CLASS_NAME :String = "linkageBaseClass";
 
     public static const SYMBOL_ITEM :String = "DOMSymbolItem";
 


### PR DESCRIPTION
If you specify Flipbook as base class of a symbol, it becomes automatically a Flipbook without needing a named layer.

If you create a jsfl file that changes the base class to Flipbook, it will be easier for an animator to manage Flipbook's movieClips.

You just need to create a Flipbook class that inherits from Movieclip at the root of the project or add the creation of the Flipbook.as file dynamically with jsfl.

(I will create JSFL tools soon)