### PR TITLE
Add tint support

### DIFF
--- a/exporter/src/main/as/flump/xfl/XflInstance.as
+++ b/exporter/src/main/as/flump/xfl/XflInstance.as
@@ -10,6 +10,8 @@ public class XflInstance
     public static const LIBRARY_ITEM_NAME :String = "libraryItemName";
     public static const IS_VISIBLE :String = "isVisible";
     public static const ALPHA :String = "alphaMultiplier";
+	public static const TINT_MULTIPLIER :String = "tintMultiplier";
+    public static const TINT :String = "tintColor";
 
     public static function getColorXml (instanceXml :XML) :XML {
         return (instanceXml.color != null ? instanceXml.color.Color[0] : null);

--- a/exporter/src/main/as/flump/xfl/XflKeyframe.as
+++ b/exporter/src/main/as/flump/xfl/XflKeyframe.as
@@ -120,6 +120,7 @@ public class XflKeyframe
         const colorXml :XML = XflInstance.getColorXml(instanceXml);
         if (colorXml != null) {
             kf.alpha = XmlUtil.getNumberAttr(colorXml, XflInstance.ALPHA, 1);
+			if (XmlUtil.hasAttr(colorXml,XflInstance.TINT_MULTIPLIER)) kf.tint = [XmlUtil.getNumberAttr(colorXml, XflInstance.TINT_MULTIPLIER, 1), XmlUtil.getStringAttr(colorXml, XflInstance.TINT)];
         }
         return kf;
     }

--- a/runtime/src/main/as/flump/mold/KeyframeMold.as
+++ b/runtime/src/main/as/flump/mold/KeyframeMold.as
@@ -31,6 +31,8 @@ public class KeyframeMold
     public var pivotX :Number = 0.0, pivotY :Number = 0.0;
 
     public var alpha :Number = 1;
+	
+	public var tint :Array;
 
     public var visible :Boolean = true;
 
@@ -50,6 +52,7 @@ public class KeyframeMold
         extractFields(o, mold, "skew", "skewX", "skewY");
         extractFields(o, mold, "pivot", "pivotX", "pivotY");
         extractField(o, mold, "alpha");
+		extractField(o, mold, "tint");
         extractField(o, mold, "visible");
         extractField(o, mold, "ease");
         extractField(o, mold, "tweened");
@@ -80,6 +83,7 @@ public class KeyframeMold
             if (skewX != 0 || skewY != 0) json.skew = [round(skewX), round(skewY)];
             if (pivotX != 0 || pivotY != 0) json.pivot = [round(pivotX), round(pivotY)];
             if (alpha != 1) json.alpha = round(alpha);
+			if (tint != null) json.tint = tint;
             if (!visible) json.visible = visible;
             if (!tweened) json.tweened = tweened;
             if (ease != 0) json.ease = round(ease);
@@ -97,7 +101,8 @@ public class KeyframeMold
             if (skewX != 0 || skewY != 0) xml.@skew = "" + round(skewX) + "," + round(skewY);
             if (pivotX != 0 || pivotY != 0) xml.@pivot = "" + round(pivotX) + "," + round(pivotY);
             if (alpha != 1) xml.@alpha = round(alpha);
-            if (!visible) xml.@visible = visible;
+            if (tint !=null) xml.@tint = "" + tint[0] + "," + tint[1];
+			if (!visible) xml.@visible = visible;
             if (!tweened) xml.@tweened = tweened;
             if (ease != 0) xml.@ease = round(ease);
         }


### PR DESCRIPTION
Add tint support in the exporter.

AS3 runtime has to be modified to manage it.
There will be a flump-pixi-runtime (haxe) version soon.
