### PR TITLE
Add customData feature

### DIFF
--- a/exporter/src/main/as/flump/SwfTexture.as
+++ b/exporter/src/main/as/flump/SwfTexture.as
@@ -27,6 +27,8 @@ public class SwfTexture
     public function get w () :int { return Math.ceil(_w * _scale); }
     public function get h () :int { return Math.ceil(_h * _scale); }
     public function get a () :int { return this.w * this.h; }
+	
+	public var data: Object;
 
     public static function fromFlipbook (lib :XflLibrary, movie :MovieMold, frame :int,
             quality :String = StageQuality.BEST, scale :Number = 1,
@@ -47,12 +49,13 @@ public class SwfTexture
         const ns :String = useNamespace ? lib.location + "/" : "";
         const disp :DisplayObject = (instance is BitmapData) ?
             new Bitmap(BitmapData(instance)) : DisplayObject(instance);
-        return new SwfTexture(ns + tex.symbol, disp, scale, quality);
+        return new SwfTexture(ns + tex.symbol, disp, scale, quality,tex.data);
     }
 
-    public function SwfTexture (symbol :String, disp :DisplayObject, scale :Number, quality :String) {
+    public function SwfTexture (symbol :String, disp :DisplayObject, scale :Number, quality :String,data:Object=null) {
         this.symbol = symbol;
         this.quality = quality;
+		this.data = data;
 
         // wrap object twice for convenience
         const wrapper :Sprite = new Sprite();

--- a/exporter/src/main/as/flump/export/AtlasImpl.as
+++ b/exporter/src/main/as/flump/export/AtlasImpl.as
@@ -53,7 +53,10 @@ public class AtlasImpl implements Atlas
             texMold.symbol = tex.symbol;
             texMold.bounds = new Rectangle(node.bounds.x, node.bounds.y, tex.w, tex.h);
             texMold.origin = new Point(tex.origin.x, tex.origin.y);
-            mold.textures.push(texMold);
+            
+			texMold.data = tex.data;
+			
+			mold.textures.push(texMold);
         });
         return mold;
     }

--- a/exporter/src/main/as/flump/xfl/XflCustomData.as
+++ b/exporter/src/main/as/flump/xfl/XflCustomData.as
@@ -1,0 +1,38 @@
+package flump.xfl 
+{
+
+	public class XflCustomData 
+	{
+		use namespace xflns;
+		
+		
+		public static function getCustomData(xmlList:XMLList) :Object
+		{
+			var data:Object={};
+			var tempValue:*;
+			var j:int;
+			
+			for (var i:String in xmlList.PD) {
+				if (xmlList.PD[i].@t=="i") tempValue=parseInt(xmlList.PD[i].@v);
+				else if (xmlList.PD[i].@t=="I") {
+					tempValue=xmlList.PD[i].@v.split(",");
+					for (j=0;j<tempValue.length;j++) tempValue[j]=parseInt(tempValue[j]);
+				}
+				else if (xmlList.PD[i].@t=="d") tempValue=parseFloat(xmlList.PD[i].@v);
+				else if (xmlList.PD[i].@t=="D") {
+					tempValue=xmlList.PD[i].@v.split(",");
+					for (j=0;j<tempValue.length;j++) tempValue[j]=parseFloat(tempValue[j]);
+				}
+				else tempValue=xmlList.PD[i].@v.toString();
+				
+				data[xmlList.PD[i].@n]=tempValue;
+			}
+			
+			for (var z:String in data) return data;
+			
+			return null;
+		}
+		
+	}
+
+}

--- a/exporter/src/main/as/flump/xfl/XflKeyframe.as
+++ b/exporter/src/main/as/flump/xfl/XflKeyframe.as
@@ -121,6 +121,15 @@ public class XflKeyframe
         if (colorXml != null) {
             kf.alpha = XmlUtil.getNumberAttr(colorXml, XflInstance.ALPHA, 1);
         }
+		
+		// Read the persistentData
+		var xmlData:XMLList = instanceXml.persistentData;
+		
+		if (instanceXml.persistentData != null) {
+			var data:Object = XflCustomData.getCustomData(instanceXml.persistentData);			
+			if (data != null) kf.data = data;
+		}
+
         return kf;
     }
 }

--- a/exporter/src/main/as/flump/xfl/XflMovie.as
+++ b/exporter/src/main/as/flump/xfl/XflMovie.as
@@ -44,10 +44,16 @@ public class XflMovie extends XflSymbol
         const exportName :String = XmlUtil.getStringAttr(xml, EXPORT_CLASS_NAME, null);
         movie.id = lib.createId(movie, name, exportName);
         const location :String = lib.location + ":" + movie.id;
-
+		
+		// persistent Data
+		if (xml.persistentData != null) {
+			var data:Object = XflCustomData.getCustomData(xml.persistentData);
+			if (data != null) movie.data = data;
+		}
+		
         const layerEls :XMLList = xml.timeline.DOMTimeline[0].layers.DOMLayer;
-        if (XmlUtil.getStringAttr(layerEls[0], XflLayer.NAME) == "flipbook") {
-            movie.layers.push(XflLayer.parse(lib, location, layerEls[0], true));
+        if (XmlUtil.getStringAttr(layerEls[0], XflLayer.NAME) == "flipbook") {			
+			movie.layers.push(XflLayer.parse(lib, location, layerEls[0], true));
             if (exportName == null) {
                 lib.addError(location, ParseError.CRIT, "Flipbook movie '" + movie.id + "' not exported");
             }

--- a/exporter/src/main/as/flump/xfl/XflTexture.as
+++ b/exporter/src/main/as/flump/xfl/XflTexture.as
@@ -10,11 +10,22 @@ import flump.executor.load.LoadedSwf;
 
 public class XflTexture
 {
-    public var symbol :String;
+    
+	use namespace xflns;
+	
+	public var symbol :String;
+    public var data :Object;
 
     public function XflTexture (lib :XflLibrary, location :String, xml :XML) {
         symbol = XmlUtil.getStringAttr(xml, "linkageClassName");
-        lib.createId(this, XmlUtil.getStringAttr(xml, "name"), symbol);
+		
+		// persistent Data
+		if (xml.persistentData!=null) {
+			var lData:Object = XflCustomData.getCustomData(xml.persistentData);
+			if (lData != null) data = lData;
+		}
+		
+        lib.createId(this, XmlUtil.getStringAttr(xml, "name"), symbol);		
     }
 
     public function isValid (lib :XflLibrary) :Boolean {

--- a/runtime/src/main/as/flump/mold/AtlasTextureMold.as
+++ b/runtime/src/main/as/flump/mold/AtlasTextureMold.as
@@ -12,6 +12,8 @@ public class AtlasTextureMold
     public var symbol :String;
     public var bounds :Rectangle;
     public var origin :Point;
+	
+	public var data : Object;
 
     public static function fromJSON (o :Object) :AtlasTextureMold {
         const mold :AtlasTextureMold = new AtlasTextureMold();
@@ -20,19 +22,26 @@ public class AtlasTextureMold
         mold.bounds = new Rectangle(rect[0], rect[1], rect[2], rect[3]);
         const orig :Array = require(o, "origin");
         mold.origin = new Point(orig[0], orig[1]);
+		
         return mold;
     }
 
     public function toJSON (_:*) :Object {
-        return {
+        var json :Object = {
             symbol: symbol,
             rect: [bounds.x, bounds.y, bounds.width, bounds.height],
             origin: [origin.x, origin.y]
         };
+		
+		if (data != null) json.data = data;
+		
+		return json;
+		
     }
 
     public function toXML () :XML {
-        const json :Object = toJSON(null);
+        //TODO: add data support. Chose a representation format for persistent Data in XML (maybe the same as in the XFL files but it's not possible in xml attributes)
+		const json :Object = toJSON(null);
         return <texture name={symbol} rect={json.rect} origin={json.origin}/>;
     }
 

--- a/runtime/src/main/as/flump/mold/KeyframeMold.as
+++ b/runtime/src/main/as/flump/mold/KeyframeMold.as
@@ -39,6 +39,9 @@ public class KeyframeMold
 
     /** Tween easing. Only valid if tweened==true. */
     public var ease :Number = 0;
+    
+	/** custom data registered on the keyframe */
+	public var data :Object;
 
     public static function fromJSON (o :Object) :KeyframeMold {
         const mold :KeyframeMold = new KeyframeMold();
@@ -54,6 +57,7 @@ public class KeyframeMold
         extractField(o, mold, "ease");
         extractField(o, mold, "tweened");
         extractField(o, mold, "label");
+        extractField(o, mold, "data");
         return mold;
     }
 
@@ -83,6 +87,7 @@ public class KeyframeMold
             if (!visible) json.visible = visible;
             if (!tweened) json.tweened = tweened;
             if (ease != 0) json.ease = round(ease);
+			if (data != null) json.data = data;
         }
         if (label != null) json.label = label;
         return json;
@@ -100,6 +105,8 @@ public class KeyframeMold
             if (!visible) xml.@visible = visible;
             if (!tweened) xml.@tweened = tweened;
             if (ease != 0) xml.@ease = round(ease);
+			//TODO: add data support. Chose a representation format for persistent Data in XML (maybe the same as in the XFL files but it's not possible in xml attributes)
+			
         }
         if (label != null) xml.@label = label;
         return xml;

--- a/runtime/src/main/as/flump/mold/MovieMold.as
+++ b/runtime/src/main/as/flump/mold/MovieMold.as
@@ -10,11 +10,14 @@ public class MovieMold
     public var id :String;
     public var layers :Vector.<LayerMold> = new <LayerMold>[];
     public var labels :Vector.<Vector.<String>>;
+	
+	public var data : Object;
 
     public static function fromJSON (o :Object) :MovieMold {
         const mold :MovieMold = new MovieMold();
-        mold.id = require(o, "id");
-        for each (var layer :Object in require(o, "layers")) mold.layers.push(LayerMold.fromJSON(layer));
+        mold.id = require(o, "id");        
+		mold.data = o["data"];
+		for each (var layer :Object in require(o, "layers")) mold.layers.push(LayerMold.fromJSON(layer));
         return mold;
     }
 
@@ -25,7 +28,7 @@ public class MovieMold
     }
 
     public function get flipbook () :Boolean {
-        return (layers.length > 0 && layers[0].flipbook);
+		return (layers.length > 0 && layers[0].flipbook);
     }
 
     public function fillLabels () :void {
@@ -68,11 +71,15 @@ public class MovieMold
             id: id,
             layers: layers
         };
+		
+		if (data != null) json.data = data;
+		
         return json;
     }
 
     public function toXML () :XML {
-        var xml :XML = <movie name={id}/>;
+		//TODO: add data support. Chose a representation format for persistent Data in XML (maybe the same as in the XFL files but it's not possible in xml attributes)
+		var xml :XML = <movie name={id}/>;
         for each (var layer :LayerMold in layers) xml.appendChild(layer.toXML());
         return xml;
     }


### PR DESCRIPTION
Adds the support of Flash Pro persistent Data in the JSON.
Adds persistent data on MovieClip, Sprite, Keyframes and you will get them in the JSON in the parameter named "data" of each entity.
The data property is an object that can contain custom data as many as you want, with correct types (string, integer, number, array of integers and numbers)

At the moment, the AS3 runtime has no direct access to these data.
flump-pixi-runtime(haxe) will support it soon.

There will be tools for simple edition of the custom data very soon.